### PR TITLE
Add Brazilian Portuguese translation

### DIFF
--- a/filedialogs/BrazilianPortuguese.h
+++ b/filedialogs/BrazilianPortuguese.h
@@ -1,0 +1,72 @@
+#ifndef IFD_QUICK_ACCESS
+#define IFD_QUICK_ACCESS "Acesso rápido"
+#endif
+#ifndef IFD_THIS_PC
+#define IFD_THIS_PC "Este computador"
+#endif
+#ifndef IFD_ALL_FILES
+#define IFD_ALL_FILES "Todos os arquivos"
+#endif
+#ifndef IFD_NAME
+#define IFD_NAME "Nome"
+#endif
+#ifndef IFD_DATE_MODIFIED
+#define IFD_DATE_MODIFIED "Data de modificação"
+#endif
+#ifndef IFD_SIZE
+#define IFD_SIZE "Tamanho"
+#endif
+#ifndef IFD_NEW_FILE
+#define IFD_NEW_FILE "Novo arquivo"
+#endif
+#ifndef IFD_NEW_DIRECTORY
+#define IFD_NEW_DIRECTORY "Nova pasta"
+#endif
+#ifndef IFD_DELETE
+#define IFD_DELETE "Excluir"
+#endif
+#ifndef IFD_ARE_YOU_SURE
+#define IFD_ARE_YOU_SURE "Tem certeza?"
+#endif
+#ifndef IFD_OVERWRITE_FILE
+#define IFD_OVERWRITE_FILE "Substituir o arquivo?"
+#endif
+#ifndef IFD_ENTER_FILE_NAME
+#define IFD_ENTER_FILE_NAME "Insira o nome do arquivo"
+#endif
+#ifndef IFD_ENTER_DIRECTORU_NAME
+#define IFD_ENTER_DIRECTORY_NAME "Insira o nome da pasta"
+#endif
+#ifndef IFD_ARE_YOU_SURE_YOU_WANT_TO_DELETE
+#define IFD_ARE_YOU_SURE_YOU_WANT_TO_DELETE "Deseja mesmo excluir %s?"
+#endif
+#ifndef IFD_ARE_YOU_SURE_YOU_WANT_TO_OVERWRITE
+#define IFD_ARE_YOU_SURE_YOU_WANT_TO_OVERWRITE "Deseja mesmo substituir %s?"
+#endif
+#ifndef IFD_YES
+#define IFD_YES "Sim"
+#endif
+#ifndef IFD_NO
+#define IFD_NO "Não"
+#endif
+#ifndef IFD_OK
+#define IFD_OK "OK"
+#endif
+#ifndef IFD_CANCEL
+#define IFD_CANCEL "Cancelar"
+#endif
+#ifndef IFD_SEARCH
+#define IFD_SEARCH "Pesquisar"
+#endif
+#ifndef IFD_FILE_NAME_WITH_COLON
+#define IFD_FILE_NAME_WITH_COLON "Nome do arquivo:"
+#endif
+#ifndef IFD_FILE_NAME_WITHOUT_COLON
+#define IFD_FILE_NAME_WITHOUT_COLON "Nome do arquivo"
+#endif
+#ifndef IFD_SAVE
+#define IFD_SAVE "Salvar"
+#endif
+#ifndef IFD_OPEN
+#define IFD_OPEN "Abrir"
+#endif


### PR DESCRIPTION
Translated all strings in a new file called `BrazilianPortuguese.h`. Feel free to move the file to a more appropriate location, or to use a different naming convention! Since it's a variant of the Portuguese language, I've seen it called `PortugueseBrazilian` (diferent word order just to group with the parent language alphabetically). The ISO language code is `pt-br` if you'd also like to name it like that.